### PR TITLE
support for ufs-s2s-model debug compilaiton (#40)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,13 @@ override NEMSDIR=$(ROOTDIR)/NEMS
 # it explicitly to make sure.  Never change this:
 override SHELL=/bin/sh
 
+# S2S_DEBUG_MODULE is used by before_components.mk for s2s-model to
+# load machine-dependent esmf debug module. Its default value is false
+# Trigger S2S_DEBUG_MODULE in one of two ways:
+# 1) argument to make call: e.g. make app=* S2S_DEBUG_MODULE=true build
+# 2) env before make call: e.g. export S2S_DEBUG_MODULE=true; make app=* build
+S2S_DEBUG_MODULE?=false
+
 # Set global variables and load utilities:
 include $(NEMSDIR)/src/incmake/infinity.mk # Recursion detector
 include $(NEMSDIR)/src/incmake/gmsl/gmsl  # GNU Make Standard Library

--- a/src/incmake/relist_components.mk
+++ b/src/incmake/relist_components.mk
@@ -56,6 +56,15 @@ override_components := \
 override COMPONENTS := $(override_components)
 
 ########################################################################
+# If FV3 MOM6 CICE all specify DEBUG=Y, set NEMS_BUILDOPT to DEBUG=Y
+ifneq (,$(findstring DEBUG=Y,$(FV3_MAKEOPT)))
+ifneq (,$(findstring DEBUG=Y,$(MOM6_MAKEOPT)))
+ifneq (,$(findstring DEBUG=Y,$(CICE_MAKEOPT)))
+  NEMS_BUILDOPT:=DEBUG=Y
+endif
+endif
+endif
+$(info NEMS_BUILDOPT IS $(NEMS_BUILDOPT))
 
 # Tools to print component options.
 


### PR DESCRIPTION
* support for ufs-s2s-model debug compilaiton

* automatically enable NEMS_BUILDOPT=DEBUG=Y based on coupledFV3_MOM6_CICE_debug.appBuilder
* automatically use esmf/8.0.0g module based on coupledFV3_MOM6_CICE_debug.appBuilder

* Change debug flag check from ifeq to findstring

* Loading machine-dependent esmf debug module

*Remove the previous approach of auto-loading esmf debug module
*Use S2S_DEBUB_MODULE env var to load machine-dependent esmf debug module
*Require ufs-s2s-model/modules/${BUILD_TARGET}/fv3_coupled_debug file