### PR TITLE
cmeps integration changes (#55)

### DIFF
--- a/src/module_EARTH_GRID_COMP.F90
+++ b/src/module_EARTH_GRID_COMP.F90
@@ -284,7 +284,7 @@
       !TODO: absorbed the needed standard names into the default dictionary.
       ! -> 20 fields identified as exports by the GSM component
 #ifdef CMEPS
-      call NUOPC_FieldDictionarySetup("fd.yaml", rc=rc)
+      call NUOPC_FieldDictionarySetup("fd_nems.yaml", rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, &
           file=__FILE__)) &
@@ -313,6 +313,17 @@
           return  ! bail out
       endif
       if (.not.NUOPC_FieldDictionaryHasEntry( &
+        "mean_zonal_moment_flx_atm")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="mean_zonal_moment_flx_atm", &
+          canonicalUnits="N m-2", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif
+      if (.not.NUOPC_FieldDictionaryHasEntry( &
         "mean_merid_moment_flx")) then
         call NUOPC_FieldDictionaryAddEntry( &
           standardName="mean_merid_moment_flx", &
@@ -324,9 +335,31 @@
           return  ! bail out
       endif
       if (.not.NUOPC_FieldDictionaryHasEntry( &
+        "mean_merid_moment_flx_atm")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="mean_merid_moment_flx_atm", &
+          canonicalUnits="N m-2", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif
+      if (.not.NUOPC_FieldDictionaryHasEntry( &
         "mean_sensi_heat_flx")) then
         call NUOPC_FieldDictionaryAddEntry( &
           standardName="mean_sensi_heat_flx", &
+          canonicalUnits="W m-2", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif
+      if (.not.NUOPC_FieldDictionaryHasEntry( &
+        "mean_sensi_heat_flx_atm")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="mean_sensi_heat_flx_atm", &
           canonicalUnits="W m-2", &
           rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -360,6 +393,17 @@
         "mean_laten_heat_flx")) then
         call NUOPC_FieldDictionaryAddEntry( &
           standardName="mean_laten_heat_flx", &
+          canonicalUnits="W m-2", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif
+      if (.not.NUOPC_FieldDictionaryHasEntry( &
+        "mean_laten_heat_flx_atm")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="mean_laten_heat_flx_atm", &
           canonicalUnits="W m-2", &
           rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -1275,6 +1319,17 @@
         "mean_net_lw_flx")) then
         call NUOPC_FieldDictionaryAddEntry( &
           standardName="mean_net_lw_flx", &
+          canonicalUnits="W m-2", &
+          rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      endif 
+      if (.not. NUOPC_FieldDictionaryHasEntry( &
+        "mean_net_lw_flx_atm")) then
+        call NUOPC_FieldDictionaryAddEntry( &
+          standardName="mean_net_lw_flx_atm", &
           canonicalUnits="W m-2", &
           rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -3412,28 +3467,10 @@
           line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
 
 #ifdef CMEPS
-        ! get file suffix
-        call NUOPC_CompAttributeGet(driver, name="inst_suffix", isPresent=isPresent, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
-        if (isPresent) then
-          call NUOPC_CompAttributeGet(driver, name="inst_suffix", value=inst_suffix, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
-        else
-          inst_suffix = ""
-        endif
+        inst_suffix = ""
 
         ! obtain driver attributes (for CMEPS)
         call ReadAttributes(driver, config, "DRIVER_attributes::", formatprint=.true., rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
-
-        call ReadAttributes(driver, config, "FLDS_attributes::", formatprint=.true., rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
-
-        call ReadAttributes(driver, config, "CLOCK_attributes::", formatprint=.true., rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__, file=trim(name)//":"//__FILE__)) return  ! bail out
 
@@ -4663,35 +4700,6 @@
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-
-    call ReadAttributes(gcomp, config, trim(compname)//"_modelio"//trim(inst_suffix)//"::", rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ReadAttributes(gcomp, config, "CLOCK_attributes::", rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    !------
-    ! Add mediator specific attributes
-    !------
-    if (compname == 'MED') then
-       call ReadAttributes(gcomp, config, "MED_history_attributes::", rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-       call ReadAttributes(gcomp, config, "FLDS_attributes::", rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-    endif
 
     !------
     ! Add multi-instance specific attributes

--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -561,10 +561,10 @@ module module_MEDIATOR
 
 
     ! Fields from ATM
-    call fld_list_add(fldsFrAtm,"mean_zonal_moment_flx"   , "cannot provide","conservefrac")
-    call fld_list_add(fldsFrAtm,"mean_merid_moment_flx"   , "will provide","conservefrac")
-    call fld_list_add(fldsFrAtm,"mean_sensi_heat_flx"     , "will provide","conservefrac")
-    call fld_list_add(fldsFrAtm,"mean_laten_heat_flx"     , "will provide","conservefrac")
+    call fld_list_add(fldsFrAtm,"mean_zonal_moment_flx_atm"   , "cannot provide","conservefrac")
+    call fld_list_add(fldsFrAtm,"mean_merid_moment_flx_atm"   , "will provide","conservefrac")
+    call fld_list_add(fldsFrAtm,"mean_sensi_heat_flx"         , "will provide","conservefrac")
+    call fld_list_add(fldsFrAtm,"mean_laten_heat_flx"         , "will provide","conservefrac")
     call fld_list_add(fldsFrAtm,"mean_down_lw_flx"        , "will provide","conservefrac")
 !    call fld_list_add(fldsFrAtm,"mean_up_lw_flx"          , "will provide","conservefrac")
     call fld_list_add(fldsFrAtm,"mean_down_sw_flx"        , "will provide","conservefrac")
@@ -5522,7 +5522,7 @@ module module_MEDIATOR
     customwgt = wgtm01 / const_lhvap
     call fieldBundle_FieldMerge(is_local%wrap%FBforOcn     , 'mean_evap_rate'             , & 
                                 is_local%wrap%FBAccumAtmOcn, 'mean_evap_rate_atm_into_ocn', atmwgt1, &
-                                is_local%wrap%FBAtm_o      , 'mean_laten_heat_flx'        , customwgt, &
+                                is_local%wrap%FBAtm_o      , 'mean_laten_heat_flx'      , customwgt, &
                                 rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
@@ -5616,7 +5616,7 @@ module module_MEDIATOR
     call fieldBundle_FieldMerge(is_local%wrap%FBforOcn     , 'mean_zonal_moment_flx'  , & 
                                 is_local%wrap%FBAccumAtmOcn, 'stress_on_air_ocn_zonal', atmwgt1, &
                                 is_local%wrap%FBIce_o      , 'stress_on_ocn_ice_zonal', icewgt1, &
-                                is_local%wrap%FBAtm_o      , 'mean_zonal_moment_flx'  , wgtm01, &
+                                is_local%wrap%FBAtm_o      , 'mean_zonal_moment_flx_atm'  , wgtm01, &
                                 rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out
@@ -5624,7 +5624,7 @@ module module_MEDIATOR
     call fieldBundle_FieldMerge(is_local%wrap%FBforOcn     , 'mean_merid_moment_flx'  , & 
                                 is_local%wrap%FBAccumAtmOcn, 'stress_on_air_ocn_merid', atmwgt1, &
                                 is_local%wrap%FBIce_o      , 'stress_on_ocn_ice_merid', icewgt1, &
-                                is_local%wrap%FBAtm_o      , 'mean_merid_moment_flx'  , wgtm01, &
+                                is_local%wrap%FBAtm_o      , 'mean_merid_moment_flx_atm'  , wgtm01, &
                                 rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, file=__FILE__)) return  ! bail out


### PR DESCRIPTION
* Bring in CMEPS

* updates to get remove CMEPS #ifdefs as much as possible

* fixed compilation bug for NEMS

* fixed problem with updates to nuopc dictionary in nems mode

* simplified removal of CMEPS in module_EARTH_GRID_COMP.F90

* fixed problem with latent heat flux

* fix divide by zero

* remove ice-ocean merge in prep_atm

* these are the changes that are consistent with the latest cmeps branch mvertens/nems_integration2_update3 that currently has a PR to cmeps master

* update pyprodutil

* updates to be consistent w/ latest s2s & cmeps

* update default values in MAIN_NEMS and module_NEMS_GRID_COMP

Co-authored-by: Mariana Vertenstein <mvertens@ucar.edu>