### PR TITLE
Bugfix i2a & Add Orion to module-setup (#61)

### DIFF
--- a/src/conf/module-setup.csh.inc
+++ b/src/conf/module-setup.csh.inc
@@ -14,6 +14,12 @@ else if ( { test -d /scratch1 -a ! -d /scratch } ) then
         source /apps/lmod/lmod/init/$__ms_shell
     endif
     module purge
+else if ( { test -d /work/noaa } ) then
+    # We are on Orion
+    if ( ! { module help >& /dev/null } ) then
+        source /apps/lmod/init/$__ms_shell
+    endif
+    module purge
 else if ( { test -d /data } ) then
     # We are on SSEC Wisconsin S4
     if ( ! { module help >& /dev/null } ) then

--- a/src/conf/module-setup.sh.inc
+++ b/src/conf/module-setup.sh.inc
@@ -28,6 +28,12 @@ elif [[ -d /scratch1 && ! -d /scratch ]] ; then
         source /apps/lmod/lmod/init/$__ms_shell
     fi
     module purge
+elif [[ -d /work/noaa ]] ; then
+    # We are on Orion
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/init/$__ms_shell
+    fi
+    module purge
 elif [[ -d /data ]] ; then
     # We are on SSEC Wisconsin S4
     if ( ! eval module help > /dev/null 2>&1 ) ; then

--- a/src/module_MEDIATOR.F90
+++ b/src/module_MEDIATOR.F90
@@ -5455,7 +5455,7 @@ module module_MEDIATOR
     !--- merges to ocn
     !---------------------------------------
 
-    if (is_local%wrap%i2a_active) then
+    if ((is_local%wrap%i2o_active) .and. (is_local%wrap%a2o_active))then
 
     ! atm and ice fraction
     ! atmwgt and icewgt are the "normal" fractions


### PR DESCRIPTION
* fix in prep_ocn for datm when i2a phase does not exist

* Add Orion to module-setup.*.inc

Co-authored-by: Denise Worthen <40498404+DeniseWorthen@users.noreply.github.com>
Co-authored-by: Denise Worthen <denise.worthen@noaa.gov>