### PR TITLE
src/incmake/component_CCPP.mk:

### DIFF
--- a/src/incmake/component_CCPP.mk
+++ b/src/incmake/component_CCPP.mk
@@ -26,12 +26,10 @@ endif
 # Process make options for CCPP build
 ifneq (,$(findstring SUITES=,$(FV3_MAKEOPT)))
   # Extract name of suite definition files using sed:
-  # - remove everything leading up to the name of the suite definition file
-  # - remove everything following the name of the suite definition file
+  # - remove everything leading up to the names of the suite definition files
+  # - remove everything following the names of the suite definition files
   SUITES = $(shell echo $(FV3_MAKEOPT) | sed 's/.* SUITES=//' | sed 's/ .*//')
   override CCPP_CONFOPT += --suites=$(SUITES)
-else
-  $(error Required suites argument missing: SUITES=xyz,abc,... (where suite xyz corresponds to file suite_xyz.xml))
 endif
 
 # Make sure the expected directories exist and are non-empty:


### PR DESCRIPTION
 SUITES argument no longer mandatory for calling ccpp_prebuild.py (#62)